### PR TITLE
MS-41/MS-42: MCP stdio server scaffold + health/state resources

### DIFF
--- a/bin/mcp-stdio.js
+++ b/bin/mcp-stdio.js
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+
+// bin/mcp-stdio.js
+// Entry point to launch the MCP server over stdio.
+// Ensures FEATURE_MCP is on by default.
+
+process.env.FEATURE_MCP = process.env.FEATURE_MCP || '1';
+process.env.MCP_TRANSPORT = process.env.MCP_TRANSPORT || 'stdio';
+
+(async () => {
+  try {
+    const logger = require('../src/utils/logger');
+    const { startMcpServer } = require('../src/mcp/server');
+    await startMcpServer();
+    logger.info('MCP stdio server started');
+  } catch (err) {
+    // MCP clients typically read stderr, keep this simple
+    console.error('MCP server failed:', err && err.stack ? err.stack : err);
+    process.exit(1);
+  }
+})();

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "zod": "^3.23.8"
       },
       "devDependencies": {
+        "@modelcontextprotocol/sdk": "^1.17.4",
         "@stoplight/spectral-cli": "^6.11.1",
         "eslint": "^8.57.0",
         "husky": "^9.1.6",
@@ -32,7 +33,7 @@
         "supertest": "^6.3.4"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=24.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1141,6 +1142,314 @@
       },
       "peerDependencies": {
         "jsep": "^0.4.0||^1.0.0"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.17.4",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.17.4.tgz",
+      "integrity": "sha512-zq24hfuAmmlNZvik0FLI58uE5sriN0WWsQzIlYnzSuKDAHFqJtBFrl/LfB1NLgJT5Y7dEBzaX4yAKqOPrcetaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.12.6",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.0.1",
+        "express-rate-limit": "^7.5.0",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.23.8",
+        "zod-to-json-schema": "^3.24.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/body-parser": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.0.tgz",
+      "integrity": "sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.0",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.6.3",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.0",
+        "raw-body": "^3.0.0",
+        "type-is": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/content-disposition": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.0.tgz",
+      "integrity": "sha512-Au9nRL8VNUut/XSzbQA38+M78dzP4D+eqg3gfJHMIHHYa3bg067xj1KxMUWj+VULbiZMowKngFFbKczUrNJ1mg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/express": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
+      "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.0",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/finalhandler": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.0.tgz",
+      "integrity": "sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/mime-types": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
+      "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/qs": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
+      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/raw-body": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.0.tgz",
+      "integrity": "sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.6.3",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/send": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.0.tgz",
+      "integrity": "sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.5",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "mime-types": "^3.0.1",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/serve-static": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.0.tgz",
+      "integrity": "sha512-61g9pCh0Vnh7IutZjtLGGpTA355+OPn2TyDv/6ivP2h/AdAVX9azsoxmg2/M6nZeQZNYBEwIcsne1mJd9oQItQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/@noble/hashes": {
@@ -4030,6 +4339,29 @@
         "node": ">=0.8.x"
       }
     },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.5.tgz",
+      "integrity": "sha512-bSRG85ZrMdmWtm7qkF9He9TNRzc/Bm99gEJMaQoHJ9E6Kv9QBbsldh2oMj7iXmYNEAVvNgvv5vPorG6W+XtBhQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -5375,6 +5707,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/is-reference": {
       "version": "1.2.1",
@@ -7740,6 +8079,16 @@
         "node": ">= 6"
       }
     },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.0.tgz",
+      "integrity": "sha512-ueGLflrrnvwB3xuo/uGob5pd5FN7l0MsLf0Z87o/UQmRtwjvfylfc9MurIxRAWywCYTgrvpXBcqjV4OfCYGCIQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
     "node_modules/pkg-dir": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
@@ -8381,6 +8730,33 @@
       },
       "optionalDependencies": {
         "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/router/node_modules/path-to-regexp": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
+      "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/run-parallel": {
@@ -9916,6 +10292,16 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.24.6",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.6.tgz",
+      "integrity": "sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg==",
+      "dev": true,
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.24.1"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -18,29 +18,31 @@
     "postinstall": "husky install",
     "openapi:lint": "spectral lint design/to-be/openapi.yaml",
     "smoke": "node scripts/smoke.js",
-    "seed": "node scripts/seed.js"
+    "seed": "node scripts/seed.js",
+    "mcp:stdio": "NODE_ENV=production FEATURE_MCP=1 node bin/mcp-stdio.js"
   },
   "dependencies": {
-    "express": "^4.18.2",
+    "better-sqlite3": "^12.2.0",
     "cors": "^2.8.5",
-    "helmet": "^7.1.0",
+    "dotenv": "^16.4.5",
+    "express": "^4.18.2",
     "express-rate-limit": "^7.1.5",
+    "helmet": "^7.1.0",
     "pino": "^9.4.0",
     "pino-http": "^10.1.0",
-    "zod": "^3.23.8",
-    "dotenv": "^16.4.5",
-    "better-sqlite3": "^12.2.0"
+    "zod": "^3.23.8"
   },
   "devDependencies": {
-    "nodemon": "^3.0.1",
+    "@modelcontextprotocol/sdk": "^1.17.4",
+    "@stoplight/spectral-cli": "^6.11.1",
     "eslint": "^8.57.0",
-    "prettier": "^3.2.5",
-    "jest": "^29.7.0",
-    "supertest": "^6.3.4",
-    "pino-pretty": "^11.2.2",
     "husky": "^9.1.6",
+    "jest": "^29.7.0",
     "lint-staged": "^15.2.10",
-    "@stoplight/spectral-cli": "^6.11.1"
+    "nodemon": "^3.0.1",
+    "pino-pretty": "^11.2.2",
+    "prettier": "^3.2.5",
+    "supertest": "^6.3.4"
   },
   "engines": {
     "node": ">=24.0.0"

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -14,7 +14,11 @@ const EnvSchema = z.object({
   // Planned (to-be): SQLite for /maps
   SQLITE_FILE: z.string().optional(),
   FEATURE_MAPS_API: z.string().optional(),
-  LOG_LEVEL: z.string().optional()
+  LOG_LEVEL: z.string().optional(),
+  // MCP (Model Context Protocol)
+  FEATURE_MCP: z.string().optional(),
+  MCP_TRANSPORT: z.enum(['stdio', 'ws']).optional(),
+  MCP_TOKEN: z.string().optional()
 });
 
 function buildConfig() {
@@ -31,7 +35,11 @@ function buildConfig() {
     featureMapsApi:
       parsed.FEATURE_MAPS_API === '1' || parsed.FEATURE_MAPS_API === 'true',
     logLevel:
-      parsed.LOG_LEVEL || (parsed.NODE_ENV === 'production' ? 'info' : 'debug')
+      parsed.LOG_LEVEL || (parsed.NODE_ENV === 'production' ? 'info' : 'debug'),
+    // MCP
+    featureMcp: parsed.FEATURE_MCP === '1' || parsed.FEATURE_MCP === 'true',
+    mcpTransport: parsed.MCP_TRANSPORT || 'stdio',
+    mcpToken: parsed.MCP_TOKEN || null
   };
   return config;
 }

--- a/src/mcp/server.js
+++ b/src/mcp/server.js
@@ -1,0 +1,110 @@
+/**
+ * src/mcp/server.js
+ * Minimal MCP server scaffold over stdio with read-only resources/tools for MS-41/MS-42.
+ * Uses dynamic import to load the MCP SDK to avoid ESM/CJS friction.
+ */
+
+const createApp = require('../factories/server-factory');
+const { config: CONFIG } = require('../config/config');
+const logger = require('../utils/logger');
+
+async function loadMcpSdk() {
+  // Prefer ESM import; Node 24 supports dynamic import in CJS
+  const mod = await import('@modelcontextprotocol/sdk/server');
+  // Handle possible API shapes
+  const Server =
+    mod.Server || (mod.default && mod.default.Server) || mod.createServer;
+  const StdioServerTransport =
+    mod.StdioServerTransport ||
+    (mod.default && mod.default.StdioServerTransport);
+  if (!Server || !StdioServerTransport) {
+    throw new Error(
+      'Unsupported MCP SDK API: expected { Server, StdioServerTransport }'
+    );
+  }
+  return { Server, StdioServerTransport };
+}
+
+function ensureMcpEnabled() {
+  if (!CONFIG.featureMcp) {
+    throw new Error(
+      'FEATURE_MCP is not enabled. Set FEATURE_MCP=1 to start the MCP server.'
+    );
+  }
+  if (CONFIG.mcpTransport !== 'stdio') {
+    throw new Error(
+      `Unsupported MCP transport: ${CONFIG.mcpTransport}. Only 'stdio' is implemented at this time.`
+    );
+  }
+}
+
+async function startMcpServer() {
+  ensureMcpEnabled();
+
+  logger.info({ transport: CONFIG.mcpTransport }, 'Starting MCP server');
+
+  // Build DI graph without opening a TCP port
+  const app = createApp(CONFIG);
+  const services = app.locals && app.locals.services ? app.locals.services : {};
+  const stateService = services.stateService;
+
+  if (!stateService) {
+    throw new Error(
+      'stateService not available; server factory must expose app.locals.services.stateService'
+    );
+  }
+
+  const { Server, StdioServerTransport } = await loadMcpSdk();
+
+  // Construct server
+  const server = new Server({ name: 'mindmeld-mcp', version: '0.1.0' });
+
+  // ---- MS-42: Resources (health + legacy state) ----
+  // Depending on SDK, this may be server.resources.add or similar. We guard and no-op if unavailable.
+  if (server.resources && typeof server.resources.add === 'function') {
+    server.resources.add({
+      uri: 'mindmeld://health',
+      mimeType: 'application/json',
+      async get() {
+        const stats = await stateService.getStats();
+        return { status: 'ok', timestamp: new Date().toISOString(), stats };
+      }
+    });
+
+    server.resources.add({
+      uri: 'mindmeld://state',
+      mimeType: 'application/json',
+      async get() {
+        const state = await stateService.readState();
+        return state;
+      }
+    });
+  } else {
+    logger.warn(
+      'MCP SDK does not expose resources.add; skipping resource registration'
+    );
+  }
+
+  // ---- MS-42: Tools (state.get) ----
+  if (server.tools && typeof server.tools.add === 'function') {
+    server.tools.add({
+      name: 'state.get',
+      description: 'Return the legacy single global state',
+      parameters: {},
+      async invoke() {
+        const state = await stateService.readState();
+        return state;
+      }
+    });
+  } else {
+    logger.warn(
+      'MCP SDK does not expose tools.add; skipping tool registration'
+    );
+  }
+
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  return server;
+}
+
+module.exports = { startMcpServer };


### PR DESCRIPTION
This PR implements Phase 1 of the MCP server work.\n\nScope:\n- MS-41 — Scaffold MCP server (stdio) behind FEATURE_MCP\n- MS-42 — Resources & tool:\n  - mindmeld://health (status, timestamp, stats)\n  - mindmeld://state (legacy global state)\n  - state.get tool (returns legacy state)\n\nImplementation:\n- Add config flags: FEATURE_MCP, MCP_TRANSPORT (default: stdio), MCP_TOKEN (reserved)\n- bin/mcp-stdio.js entry: starts MCP over stdio\n- src/mcp/server.js: uses McpServer API to register resources/tools and connect over stdio\n- package.json: add script "mcp:stdio"\n\nHow to run:\n- npm run mcp:stdio (launches stdio server for MCP-compatible clients)\n\nNotes:\n- Read-only phase; maps support to follow in MS-43/MS-44\n- Server DI is reused; no HTTP port is opened by MCP.\n