### PR TITLE
Remove legacy /api/state; maps-first server

### DIFF
--- a/src/config/config.js
+++ b/src/config/config.js
@@ -8,10 +8,7 @@ const EnvSchema = z.object({
   NODE_ENV: z
     .enum(['development', 'production', 'test'])
     .default('development'),
-  STATE_FILE_PATH: z
-    .string()
-    .default(path.join(process.cwd(), 'data', 'state.json')),
-  // Planned (to-be): SQLite for /maps
+  // SQLite for /maps
   SQLITE_FILE: z.string().optional(),
   FEATURE_MAPS_API: z.string().optional(),
   LOG_LEVEL: z.string().optional(),
@@ -26,14 +23,15 @@ function buildConfig() {
   const config = {
     port: parseInt(parsed.PORT, 10),
     corsOrigin: parsed.CORS_ORIGIN,
-    stateFilePath: parsed.STATE_FILE_PATH,
     jsonLimit: parsed.JSON_LIMIT,
     nodeEnv: parsed.NODE_ENV,
     // Planned
     sqliteFile:
       parsed.SQLITE_FILE || path.join(process.cwd(), 'data', 'db.sqlite'),
-    featureMapsApi:
-      parsed.FEATURE_MAPS_API === '1' || parsed.FEATURE_MAPS_API === 'true',
+    // default ON unless explicitly disabled
+    featureMapsApi: !(
+      parsed.FEATURE_MAPS_API === '0' || parsed.FEATURE_MAPS_API === 'false'
+    ),
     logLevel:
       parsed.LOG_LEVEL || (parsed.NODE_ENV === 'production' ? 'info' : 'debug'),
     // MCP

--- a/src/factories/server-factory.js
+++ b/src/factories/server-factory.js
@@ -4,10 +4,7 @@
  */
 
 const express = require('express');
-const path = require('path');
 
-const FileStorage = require('../data/file-storage');
-const StateService = require('../services/state-service');
 const createApiRoutes = require('../core/api-routes');
 const createMiddleware = require('../core/middleware');
 const createDocsRouter = require('../core/docs-route');
@@ -22,34 +19,28 @@ function createServer(config = {}) {
   const {
     port = 3001,
     corsOrigin = 'http://localhost:8080',
-    stateFilePath = path.join(process.cwd(), 'data', 'state.json'),
     jsonLimit = '50mb'
   } = config;
 
   Logger.info('Creating server with configuration', {
     port,
     corsOrigin,
-    stateFilePath,
     jsonLimit
   });
 
   // Create Express app
   const app = express();
 
-  // Create services with dependency injection
-  const storage = new FileStorage(stateFilePath);
-  const stateService = new StateService(storage);
-
   // Apply middleware
   const middleware = createMiddleware({ corsOrigin, jsonLimit });
   middleware.forEach(mw => app.use(mw));
 
   // Apply routes
-  const apiRoutes = createApiRoutes(stateService);
+  const apiRoutes = createApiRoutes();
   app.use('/', apiRoutes);
 
-  // Feature-flagged /maps router (to-be API)
-  if (config && config.featureMapsApi === true) {
+  // /maps router (enabled by default)
+  if (!config || config.featureMapsApi !== false) {
     const createMapsRouter = require('../modules/maps/routes');
     app.use('/maps', createMapsRouter({ sqliteFile: config.sqliteFile }));
   }
@@ -79,16 +70,10 @@ function createServer(config = {}) {
   const { errorHandler } = require('../core/error-handler');
   app.use(errorHandler);
 
-  // Store services on app for testing access
-  app.locals.services = {
-    storage,
-    stateService
-  };
-
+  // Store minimal config on app
   app.locals.config = {
     port,
     corsOrigin,
-    stateFilePath,
     jsonLimit
   };
 

--- a/src/index.js
+++ b/src/index.js
@@ -15,8 +15,11 @@ const { config: CONFIG } = require('./config/config');
  * Ensure data directory exists
  */
 async function ensureDataDirectory() {
-  const dataDir = path.dirname(CONFIG.stateFilePath);
   try {
+    if (!CONFIG || CONFIG.featureMapsApi === false) {
+      return;
+    }
+    const dataDir = path.dirname(CONFIG.sqliteFile);
     await fs.mkdir(dataDir, { recursive: true });
     Logger.info(`Data directory ensured: ${dataDir}`);
   } catch (error) {
@@ -93,10 +96,9 @@ async function startServer() {
     // Start listening
     const server = app.listen(CONFIG.port, () => {
       Logger.info({ port: CONFIG.port }, '🚀 MindMeld Server running');
-      Logger.info({ stateFile: CONFIG.stateFilePath }, '📁 State file');
       Logger.info({ health: '/health', ready: '/ready' }, 'Probes available');
       Logger.info({ corsOrigin: CONFIG.corsOrigin }, '🌐 CORS origin');
-      Logger.info({ stats: '/api/state/stats' }, '📊 Stats endpoint');
+      Logger.info({ maps: '/maps' }, '🗺️ Maps API enabled');
 
       eventBus.emit('server.started', {
         port: CONFIG.port,


### PR DESCRIPTION
This PR removes the legacy file-based /api/state surface and switches the server to maps-first.\n\nChanges:\n- Remove StateService/FileStorage wiring and all /api/state routes\n- Health/ready endpoints remain\n- Enable /maps by default; ensure data dir from SQLITE_FILE\n- Update config: default FEATURE_MAPS_API=true (unless explicitly set to 0/false)\n- Index logs now advertise /maps; removed state logs\n- MCP server simplified to health resource only (state tooling removed); maps tooling to follow\n- Docs: testing guide updated to maps-only flows\n\nFollow-ups:\n- Update README and CONTEXT to fully remove /api/state references\n- Add MCP maps resources/tools (MS-43/MS-44)\n- Update/clean tests to reflect maps-first\n