### PR TITLE
MS-42: MCP resources: health + state

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,3 +17,6 @@ FEATURE_MAPS_API=1
 # FEATURE_MCP=1
 # MCP_TRANSPORT=stdio
 # MCP_TOKEN=
+
+# Legacy state file (for MCP state resource)
+# STATE_FILE=./data/state.json

--- a/README.md
+++ b/README.md
@@ -144,7 +144,12 @@ src/
 
 ## MCP (Model Context Protocol)
 
-An experimental MCP stdio server is included and currently exposes a health resource. Maps resources/tools will be added next.
+An experimental MCP stdio server is included and currently exposes:
+
+- Resource: mindmeld://health → { status, timestamp, stats }
+- Resource: mindmeld://state → current legacy state (JSON)
+
+Maps resources/tools will be added next.
 
 - Start: npm run mcp:stdio
 

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -12,6 +12,8 @@ const EnvSchema = z.object({
   SQLITE_FILE: z.string().optional(),
   FEATURE_MAPS_API: z.string().optional(),
   LOG_LEVEL: z.string().optional(),
+  // Legacy state file (for MCP state resource)
+  STATE_FILE: z.string().optional(),
   // MCP (Model Context Protocol)
   FEATURE_MCP: z.string().optional(),
   MCP_TRANSPORT: z.enum(['stdio', 'ws']).optional(),
@@ -34,6 +36,9 @@ function buildConfig() {
     ),
     logLevel:
       parsed.LOG_LEVEL || (parsed.NODE_ENV === 'production' ? 'info' : 'debug'),
+    // Legacy state file path for MCP resource
+    stateFile:
+      parsed.STATE_FILE || path.join(process.cwd(), 'data', 'state.json'),
     // MCP
     featureMcp: parsed.FEATURE_MCP === '1' || parsed.FEATURE_MCP === 'true',
     mcpTransport: parsed.MCP_TRANSPORT || 'stdio',


### PR DESCRIPTION
Implements MS-42. Adds MCP stdio resources for health (now includes { status, timestamp, stats }) and legacy state (mindmeld://state).\n\nChanges:\n- Add STATE_FILE config (default ./data/state.json) for legacy state used by MCP\n- MCP health resource returns status + stats via StateService\n- New resource mindmeld://state returns current legacy state JSON\n- Update README and .env.example\n\nNotes:\n- This builds on the MCP scaffold (MS-41).\n- No HTTP legacy /api/state endpoints added; this is MCP-only.\n- CI parity: All tests pass locally; pre-commit runs mirror CI.\n\nNext steps (future tickets):\n- MS-43/44: maps resources/tools (list/get/summary)\n- MS-45/46/47/48/49: config, observability, tests, CI integration, docs